### PR TITLE
Allow binding variables to loggers

### DIFF
--- a/eliot/_output.py
+++ b/eliot/_output.py
@@ -88,6 +88,16 @@ class ILogger(Interface):
     """
     Write out message dictionaries to some destination.
     """
+    def bind(**arguments):
+        """
+		Bind given argument(s) to this logger.
+
+        Every message logged via this logger will include these arguments
+
+        @param **arguments: key/value pairs to bind to this logger
+		"""
+
+
     def write(dictionary, serializer=None):
         """
         Write a dictionary to the appropriate destination.
@@ -114,6 +124,11 @@ class Logger(object):
     """
     _destinations = Destinations()
 
+
+    def __init__(self):
+        self.binded_args = dict()
+
+
     def _safeUnicodeDictionary(self, dictionary):
         """
         Serialize a dictionary to a unicode string no matter what it contains.
@@ -134,11 +149,18 @@ class Logger(object):
             return saferepr(dictionary)
 
 
+    def bind(self, **arguments):
+        """
+        Bind given arguments to this logger
+        """
+        self.binded_args.update(arguments)
+
+
     def write(self, dictionary, serializer=None):
         """
         Serialize the dictionary, and write it to C{self._destinations}.
         """
-        dictionary = dictionary.copy()
+        dictionary = dict(self.binded_args, **dictionary.copy())
         try:
             if serializer is not None:
                 serializer.serialize(dictionary)
@@ -185,6 +207,7 @@ class MemoryLogger(object):
     """
     def __init__(self):
         self.reset()
+        self.binded_args = dict()
 
 
     def flushTracebacks(self, exceptionType):
@@ -213,11 +236,18 @@ class MemoryLogger(object):
     flush_tracebacks = flushTracebacks
 
 
+    def bind(self, **arguments):
+        """
+        Bind given arguments to this logger
+        """
+        self.binded_args.update(arguments)
+
+
     def write(self, dictionary, serializer=None):
         """
         Add the dictionary to list of messages.
         """
-        self.messages.append(dictionary)
+        self.messages.append(dict(self.binded_args, **dictionary))
         self.serializers.append(serializer)
         if serializer is TRACEBACK_MESSAGE._serializer:
             self.tracebackMessages.append(dictionary)

--- a/eliot/tests/test_output.py
+++ b/eliot/tests/test_output.py
@@ -42,6 +42,17 @@ class MemoryLoggerTests(TestCase):
         logger.validate()
 
 
+    def test_write_binded(self):
+        """
+        Binded values are stored on a list.
+        """
+        logger = MemoryLogger()
+        logger.bind(a='b')
+        logger.write({'c': 1})
+        self.assertEqual(logger.messages, [{'a': 'b', 'c': 1}])
+        logger.validate()
+
+
     def test_notStringFieldKeys(self):
         """
         Field keys must be unicode or bytes; if not L{MemoryLogger.validate}
@@ -362,6 +373,19 @@ class LoggerTests(TestCase):
         d = {"hello": 1}
         logger.write(d)
         self.assertEqual(written, [d])
+
+
+    def test_write_binded(self):
+        """
+        Values added in L{Logger.bind} are are included in messages sent to
+        the L{Destinations} object.
+        """
+        logger, written = makeLogger()
+
+        logger.bind(hi=0)
+        d = {"hello": 1}
+        logger.write(d)
+        self.assertEqual(written, [{"hi": 0, "hello": 1}])
 
 
     def test_serializer(self):


### PR DESCRIPTION
This is to allow custom arguments to be logged with every message
returned by a logger.

Use-case: in centralized logging, I want to know which application
generated every message.
