### PR TITLE
Better error message for missing end messages

### DIFF
--- a/docs/source/news.rst
+++ b/docs/source/news.rst
@@ -9,6 +9,7 @@ Features:
 * Generating messages is much faster.
 * ``eliot.ValidationError``, as raised by e.g. ``capture_logging``, is now part of the public API. Fixed issue #146.
 * ``eliot.twisted.DeferredContext.addCallbacks`` now supports omitting the errback, for compatibility with Twisted's ``Deferred``. Thanks to Jean-Paul Calderone for the fix. Fixed issue #366.
+* The testing infrastructure now has slightly more informative error messages. Thanks to Jean-Paul Calderone for the bugfix. Fixes issue #373.
 
 1.6.0
 ^^^^^

--- a/docs/source/news.rst
+++ b/docs/source/news.rst
@@ -9,7 +9,7 @@ Features:
 * Generating messages is much faster.
 * ``eliot.ValidationError``, as raised by e.g. ``capture_logging``, is now part of the public API. Fixed issue #146.
 * ``eliot.twisted.DeferredContext.addCallbacks`` now supports omitting the errback, for compatibility with Twisted's ``Deferred``. Thanks to Jean-Paul Calderone for the fix. Fixed issue #366.
-* The testing infrastructure now has slightly more informative error messages. Thanks to Jean-Paul Calderone for the bugfix. Fixes issue #373.
+* The testing infrastructure now has slightly more informative error messages. Thanks to Jean-Paul Calderone for the bug report. Fixes issue #373.
 
 1.6.0
 ^^^^^

--- a/eliot/testing.py
+++ b/eliot/testing.py
@@ -141,8 +141,12 @@ class LoggedAction(PClass):
                 child = klass.fromMessages(
                     uuid, message[TASK_LEVEL_FIELD], messages)
                 children.append(child)
-        if startMessage is None or endMessage is None:
-            raise ValueError(uuid, level)
+        if startMessage is None:
+            raise ValueError("Missing start message")
+        if endMessage is None:
+            raise ValueError(
+                "Missing end message of type " + message.get(
+                    ACTION_TYPE_FIELD, "unknown"))
         return klass(startMessage, endMessage, children)
 
     # PEP 8 variant:
@@ -401,24 +405,24 @@ def assertHasAction(
 
     @param logger: L{eliot.MemoryLogger} whose messages will be checked.
 
-    @param actionType: L{eliot.ActionType} indicating which message we're
-        looking for.
+    @param actionType: L{eliot.ActionType} or C{str} indicating which message
+        we're looking for.
 
     @param succeeded: Expected success status of the action, a C{bool}.
 
     @param startFields: The first action of the given type found must have a
-        superset of the given C{dict} as its start fields. If C{None} then
+        superset of the given C{dict} as its start fields.  If C{None} then
         fields are not checked.
 
     @param endFields: The first action of the given type found must have a
-        superset of the given C{dict} as its end fields. If C{None} then
+        superset of the given C{dict} as its end fields.  If C{None} then
         fields are not checked.
 
     @return: The first found L{LoggedAction} of the given type, if field
         validation succeeded.
 
-    @raises AssertionError: No action was found, or the fields were not superset
-        of given fields.
+    @raises AssertionError: No action was found, or the fields were not
+        superset of given fields.
     """
     if startFields is None:
         startFields = {}

--- a/eliot/tests/test_testing.py
+++ b/eliot/tests/test_testing.py
@@ -130,7 +130,7 @@ class LoggedActionTests(TestCase):
         is not found.
         """
         logger = MemoryLogger()
-        with start_action(logger, "test"):
+        with start_action(logger, action_type="test"):
             pass
         self.assertRaises(
             ValueError, self.fromMessagesIndex, logger.messages[1:], 0)
@@ -141,10 +141,12 @@ class LoggedActionTests(TestCase):
         is not found.
         """
         logger = MemoryLogger()
-        with start_action(logger, "test"):
+        with start_action(logger, action_type="test"):
             pass
-        self.assertRaises(
-            ValueError, self.fromMessagesIndex, logger.messages[:1], 0)
+        with self.assertRaises(ValueError) as cm:
+            self.fromMessagesIndex(logger.messages[:1], 0)
+        self.assertEqual(cm.exception.args[0],
+                         "Missing end message of type test")
 
     def test_fromMessagesAddsChildMessages(self):
         """


### PR DESCRIPTION
Fixes #373.

I believe start messages are already covered by the existing code in `assertHasAction`, where missing start messages will result in empty list of messages, and there's already logic for that with a human-readable message.

@exarkun 