### PR TITLE
Lower-level API for capturing logs during tests

### DIFF
--- a/docs/source/generating/index.rst
+++ b/docs/source/generating/index.rst
@@ -8,8 +8,8 @@ Generating Logs
    loglevels
    migrating
    threads
+   testing
    types
-   types-testing
    asyncio
    twisted
 

--- a/docs/source/generating/testing.rst
+++ b/docs/source/generating/testing.rst
@@ -252,6 +252,6 @@ You can achieve the same effect, but with more control, with some lower-level AP
            run_some_code()
        finally:
            # Validate log messages, check for tracebacks:
-           check_for_errors(logger)
+           check_for_errors(test_logger)
            # Restore original logging setup:
            swap_logger(original_logger)

--- a/docs/source/generating/testing.rst
+++ b/docs/source/generating/testing.rst
@@ -251,7 +251,8 @@ You can achieve the same effect, but with more control, with some lower-level AP
        try:
            run_some_code()
        finally:
-           # Validate log messages, check for tracebacks:
-           check_for_errors(test_logger)
            # Restore original logging setup:
            swap_logger(original_logger)
+           # Validate log messages, check for tracebacks:
+           check_for_errors(test_logger)
+           

--- a/docs/source/generating/testing.rst
+++ b/docs/source/generating/testing.rst
@@ -1,19 +1,38 @@
-Unit Testing Your Logging
-=========================
-
-Validate Logging in Tests
--------------------------
+Unit Testing Your Logging with Types
+====================================
 
 Now that you've got some code emitting log messages (or even better, before you've written the code) you can write unit tests to verify it.
 Given good test coverage all code branches should already be covered by tests unrelated to logging.
 Logging can be considered just another aspect of testing those code branches.
 Rather than recreating all those tests as separate functions Eliot provides a decorator the allows adding logging assertions to existing tests.
 
-Let's unit test some code that relies on the ``LOG_USER_REGISTRATION`` object we created earlier.
+
+Linting your logs
+-----------------
+
+Decorating a test function with ``eliot.testing.capture_logging`` validation will ensure that:
+
+1. You haven't logged anything that isn't JSON serializable.
+2. There are no unexpected tracebacks, indicating a bug somewhere in your code.
 
 .. code-block:: python
 
-      from myapp.logtypes import LOG_USER_REGISTRATION
+   from eliot.testing import capture_logging
+
+   class MyTest(unittest.TestCase):
+      @capture_logging(None)
+      def test_mytest(self, logger):
+          call_my_function()
+
+
+Making assertions about the logs
+--------------------------------
+
+You can also ensure the correct messages were logged.
+
+.. code-block:: python
+
+      from eliot import Message
 
       class UserRegistration(object):
 
@@ -22,8 +41,9 @@ Let's unit test some code that relies on the ``LOG_USER_REGISTRATION`` object we
 
           def register(self, username, password, age):
               self.db[username] = (password, age)
-              LOG_USER_REGISTRATION(
-                   username=username, password=password, age=age).write()
+              Message.log(message_type="user_registration",
+                          username=username, password=password,
+                          age=age)
 
 
 Here's how we'd test it:
@@ -35,7 +55,6 @@ Here's how we'd test it:
     from eliot.testing import assertContainsFields, capture_logging
 
     from myapp.registration import UserRegistration
-    from myapp.logtypes import LOG_USER_REGISTRATION
 
 
     class LoggingTests(TestCase):
@@ -58,13 +77,6 @@ Here's how we'd test it:
             registry = UserRegistration()
             registry.register(u"john", u"password", 12)
             self.assertEqual(registry.db[u"john"], (u"passsword", 12))
-
-
-Besides calling the given validation function the ``@capture_logging`` decorator will also validate the logged messages after the test is done.
-E.g. it will make sure they are JSON encodable.
-Messages were created using ``ActionType`` and ``MessageType`` will be validated using the applicable ``Field`` definitions.
-You can also call ``MemoryLogger.validate`` yourself to validate written messages.
-If you don't want any additional logging assertions you can decorate your test function using ``@capture_logging(None)``.
 
 
 Testing Tracebacks
@@ -96,14 +108,14 @@ Testing Message and Action Structure
 ------------------------------------
 
 Eliot provides utilities for making assertions about the structure of individual messages and actions.
-The simplest method is using the ``assertHasMessage`` utility function which asserts that a message of a given ``MessageType`` has the given fields:
+The simplest method is using the ``assertHasMessage`` utility function which asserts that a message of a given message type has the given fields:
 
 .. code-block:: python
 
     from eliot.testing import assertHasMessage, capture_logging
 
     class LoggingTests(TestCase):
-        @capture_logging(assertHasMessage, LOG_USER_REGISTRATION,
+        @capture_logging(assertHasMessage, "user_registration",
                          {u"username": u"john",
                           u"password": u"password",
                           u"age": 12})
@@ -119,7 +131,7 @@ The simplest method is using the ``assertHasMessage`` utility function which ass
 ``assertHasMessage`` returns the found message and can therefore be used within more complex assertions. ``assertHasAction`` provides similar functionality for actions (see example below).
 
 More generally, ``eliot.testing.LoggedAction`` and ``eliot.testing.LoggedMessage`` are utility classes to aid such testing.
-``LoggedMessage.of_type`` lets you find all messages of a specific ``MessageType``.
+``LoggedMessage.of_type`` lets you find all messages of a specific message type.
 A ``LoggedMessage`` has an attribute ``message`` which contains the logged message dictionary.
 For example, we could rewrite the registration logging test above like so:
 
@@ -132,7 +144,7 @@ For example, we could rewrite the registration logging test above like so:
             """
             Logging assertions for test_registration.
             """
-            logged = LoggedMessage.of_type(logger.messages, LOG_USER_REGISTRATION)[0]
+            logged = LoggedMessage.of_type(logger.messages, "user_registration")[0]
             assertContainsFields(self, logged.message,
                                  {u"username": u"john",
                                   u"password": u"password",
@@ -148,7 +160,7 @@ For example, we could rewrite the registration logging test above like so:
             self.assertEqual(registry.db[u"john"], (u"passsword", 12))
 
 
-Similarly, ``LoggedAction.of_type`` finds all logged actions of a specific ``ActionType``.
+Similarly, ``LoggedAction.of_type`` finds all logged actions of a specific action type.
 A ``LoggedAction`` instance has ``start_message`` and ``end_message`` containing the respective message dictionaries, and a ``children`` attribute containing a list of child ``LoggedAction`` and ``LoggedMessage``.
 That is, a ``LoggedAction`` knows about the messages logged within its context.
 ``LoggedAction`` also has a utility method ``descendants()`` that returns an iterable of all its descendants.
@@ -158,19 +170,18 @@ For example, let's say we have some code like this:
 
 .. code-block:: python
 
-    LOG_SEARCH = ActionType(...)
-    LOG_CHECK = MessageType(...)
+    from eliot import start_action, Message
 
     class Search:
         def search(self, servers, database, key):
-            with LOG_SEARCH(database=database, key=key):
+            with start_action(action_type="log_search", database=database, key=key):
             for server in servers:
-                LOG_CHECK(server=server).write()
+                Message.log(message_type="log_check", server=server)
                 if server.check(database, key):
                     return True
             return False
 
-We want to assert that the LOG_CHECK message was written in the context of the LOG_SEARCH action.
+We want to assert that the "log_check" message was written in the context of the "log_search" action.
 The test would look like this:
 
 .. code-block:: python
@@ -185,8 +196,8 @@ The test would look like this:
             servers = [buildServer(), buildServer()]
 
             searcher.search(servers, "users", "theuser")
-            action = LoggedAction.of_type(logger.messages, searcher.LOG_SEARCH)[0]
-            messages = LoggedMessage.of_type(logger.messages, searcher.LOG_CHECK)
+            action = LoggedAction.of_type(logger.messages, "log_search")[0]
+            messages = LoggedMessage.of_type(logger.messages, "log_check")
             # The action start message had the appropriate fields:
             assertContainsFields(self, action.start_message,
                                  {"database": "users", "key": "theuser"})
@@ -210,103 +221,12 @@ Or we can simplify further by using ``assertHasMessage`` and ``assertHasAction``
             servers = [buildServer(), buildServer()]
 
             searcher.search(servers, "users", "theuser")
-            action = assertHasAction(self, logger, searcher.LOG_SEARCH, succeeded=True,
+            action = assertHasAction(self, logger, "log_search", succeeded=True,
                                      startFields={"database": "users",
                                                   "key": "theuser"})
 
             # Messages were logged in the context of the action
-            messages = LoggedMessage.of_type(logger.messages, searcher.LOG_CHECK)
+            messages = LoggedMessage.of_type(logger.messages, "log_check")
             self.assertEqual(action.children, messages)
             # Each message had the respective server set.
             self.assertEqual(servers, [msg.message["server"] for msg in messages])
-
-
-Restricting Testing to Specific Messages
-----------------------------------------
-
-If you want to only look at certain messages when testing you can log to a specific ``eliot.Logger`` object.
-The messages will still be logged normally but you will be able to limit tests to only looking at those messages.
-
-You can log messages to a specific ``Logger``:
-
-.. code-block:: python
-
-    from eliot import Message, Logger
-
-    class YourClass(object):
-        logger = Logger()
-
-        def run(self):
-            # Create a message with two fields, "key" and "value":
-            msg = Message.new(key=123, value=u"hello")
-            # Write the message:
-            msg.write(self.logger)
-
-As well as actions:
-
-.. code-block:: python
-
-     from eliot import start_action
-
-     logger = Logger()
-
-     with start_action(logger, action_type=u"store_data"):
-         x = get_data()
-         store_data(x)
-
-Or actions created from ``ActionType``:
-
-.. code-block:: python
-
-    from eliot import Logger
-
-      from myapp.logtypes import LOG_USER_REGISTRATION
-
-      class UserRegistration(object):
-
-          logger = Logger()
-
-          def __init__(self):
-              self.db = {}
-
-          def register(self, username, password, age):
-              self.db[username] = (password, age)
-              msg = LOG_USER_REGISTRATION(
-                   username=username, password=password, age=age)
-              # Notice use of specific logger:
-              msg.write(self.logger)
-
-The tests would then need to do two things:
-
-1. Decorate your test with ``validate_logging`` instead of ``capture_logging``.
-2. Override the logger used by the logging code to use the one passed in to the test.
-
-For example:
-
-.. code-block:: python
-
-    from eliot.testing import LoggedMessage, validate_logging
-
-    class LoggingTests(TestCase):
-        def assertRegistrationLogging(self, logger):
-            """
-            Logging assertions for test_registration.
-            """
-            logged = LoggedMessage.of_type(logger.messages, LOG_USER_REGISTRATION)[0]
-            assertContainsFields(self, logged.message,
-                                 {u"username": u"john",
-                                  u"password": u"password",
-                                  u"age": 12}))
-
-        # validate_logging only captures log messages logged to the MemoryLogger
-        # instance it passes to the test:
-        @validate_logging(assertRegistrationLogging)
-        def test_registration(self, logger):
-            """
-            Registration adds entries to the in-memory database.
-            """
-            registry = UserRegistration()
-            # Override logger with one used by test:
-            registry.logger = logger
-            registry.register(u"john", u"password", 12)
-            self.assertEqual(registry.db[u"john"], (u"password", 12))

--- a/docs/source/generating/testing.rst
+++ b/docs/source/generating/testing.rst
@@ -230,3 +230,28 @@ Or we can simplify further by using ``assertHasMessage`` and ``assertHasAction``
             self.assertEqual(action.children, messages)
             # Each message had the respective server set.
             self.assertEqual(servers, [msg.message["server"] for msg in messages])
+
+
+Custom testing setup
+--------------------
+
+In some cases ``@capture_logging`` may not do what you want.
+You can achieve the same effect, but with more control, with some lower-level APIs:
+
+.. code-block:: python
+
+   from eliot import MemoryLogger
+   from eliot.testing import swap_logger, check_for_errors
+
+   def custom_capture_logging():
+       # Replace default logging setup with a testing logger:
+       test_logger = MemoryLogger()
+       original_logger = swap_logger(test_logger)
+
+       try:
+           run_some_code()
+       finally:
+           # Validate log messages, check for tracebacks:
+           check_for_errors(logger)
+           # Restore original logging setup:
+           swap_logger(original_logger)

--- a/docs/source/generating/types.rst
+++ b/docs/source/generating/types.rst
@@ -9,7 +9,8 @@ Why Typing?
 So far we've been creating messages and actions in an unstructured manner.
 This means it's harder to support Python objects that aren't built-in and to validate message structure.
 Moreover there's no documentation of what fields messages and action messages expect.
-To improve this we introduce the preferred API for creating actions and standalone messages: ``ActionType`` and ``MessageType``.
+
+To improve this we introduce an optional API for creating actions and standalone messages: ``ActionType`` and ``MessageType``.
 Here's an example demonstrating how we create a message type, bind some values and then log the message:
 
 .. code-block:: python
@@ -190,3 +191,11 @@ If a message fails to serialize then a ``eliot:traceback`` message will be logge
     {"timestamp": "2013-11-22T14:16:51.386827Z",
      "message": "{u\"u'message_type'\": u\"'test'\", u\"u'field'\": u\"'hello'\", u\"u'timestamp'\": u\"'2013-11-22T14:16:51.386634Z'\"}",
      "message_type": "eliot:serialization_failure"}
+
+Testing
+-------
+
+The ``eliot.testing.assertHasAction`` and ``assertHasMessage`` APIs accept ``ActionType`` and ``MessageType`` instances, not just the ``action_type`` and ``message_type`` strings.
+
+Any function decorated with ``@capture_logging`` will additionally validate messages that were created using ``ActionType`` and ``MessageType`` using the applicable ``Field`` definitions.
+This will ensure you've logged all the necessary fields, no additional fields, and used the correct types.

--- a/docs/source/news.rst
+++ b/docs/source/news.rst
@@ -4,12 +4,17 @@ What's New
 1.7.0
 ^^^^^
 
+Documentation:
+
+* Eliot has an API for testing your logs were output correctly. Until now, however, the documentation was overly focused on requiring usage of types, which are optional, so it has been rewritten to be more generic: :doc:`read more about the testing API here<generating/testing>`.
+
 Features:
 
 * Generating messages is much faster.
 * ``eliot.ValidationError``, as raised by e.g. ``capture_logging``, is now part of the public API. Fixed issue #146.
 * ``eliot.twisted.DeferredContext.addCallbacks`` now supports omitting the errback, for compatibility with Twisted's ``Deferred``. Thanks to Jean-Paul Calderone for the fix. Fixed issue #366.
-* The testing infrastructure now has slightly more informative error messages. Thanks to Jean-Paul Calderone for the bug report. Fixes issue #373.
+* Added lower-level testing infrastructure—``eliot.testing.swap_logger`` and ``eliot.testing.check_for_errors``—which is useful for cases when the ``@capture_logging`` decorator is insufficient. For example, test methods that are async, or return Twisted ``Deferred``. See the :doc:`testing documentation<generating/testing>` for details. Thanks to Jean-Paul Calderone for the feature request. Fixes #364.
+* The testing API now has slightly more informative error messages. Thanks to Jean-Paul Calderone for the bug report. Fixes issue #373.
 * ILogger.write is now explicitly thread-safe.  The MemoryLogger implementation of this method which was previously not thread-safe is now thread-safe.
 
 1.6.0

--- a/eliot/tests/test_testing.py
+++ b/eliot/tests/test_testing.py
@@ -703,30 +703,6 @@ class CaptureLoggingTests(ValidateLoggingTestsMixin, TestCase):
             (test.recorded, result.skipped, result.errors, result.failures),
             (False, [(test, "Do not run this test.")], [], []))
 
-    def test_unflushedTracebacksDontFailForSkip(self):
-        """
-        If the decorated test raises L{SkipTest} then the unflushed traceback
-        checking normally implied by L{validateLogging} is also skipped.
-        """
-
-        class MyTest(TestCase):
-            @validateLogging(lambda self, logger: None)
-            def runTest(self, logger):
-                try:
-                    1 / 0
-                except:
-                    write_traceback(logger)
-                raise SkipTest("Do not run this test.")
-
-        test = MyTest()
-        result = TestResult()
-        test.run(result)
-
-        # Verify that there was only a skip, no additional errors or failures
-        # reported.
-        self.assertEqual((1, [], []),
-                         (len(result.skipped), result.errors, result.failures))
-
 
 MESSAGE1 = MessageType(
     "message1", [Field.forTypes("x", [int], "A number")],


### PR DESCRIPTION
Fixes #364.

Also makes testing documentation not dependent on type system.