### PR TITLE
Generator decorator for inlineCallbacks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,9 @@
+# Guidelines for Pull Requests
+
+Ideally the following would be included:
+
+* Tests.
+* A changelog entry in `docs/sources/news.rst`, if it's something non-trivial.
+* Documentation if it's a new feature.
+
+However, if you have some code in progress and you don't have the time for all the above, submit the PR anyway and we'll figure something out.

--- a/docs/source/generating/actions.rst
+++ b/docs/source/generating/actions.rst
@@ -132,6 +132,31 @@ You can add fields to both the start message and the success message of an actio
 If you want to include some extra information in case of failures beyond the exception you can always log a regular message with that information.
 Since the message will be recorded inside the context of the action its information will be clearly tied to the result of the action by the person (or code!) reading the logs later on.
 
+Using Generators
+----------------
+
+Generators (functions with ``yield``) and context managers (``with X:``) don't mix well in Python.
+So if you're going to use ``with start_action()`` in a generator, just make sure it doesn't wrap a ``yield`` and you'll be fine.
+
+Here's what you SHOULD NOT DO:
+
+.. code-block:: python
+
+   def generator():
+       with start_action(action_type="x"):
+           # BAD! DO NOT yield inside a start_action() block:
+           yield make_result()
+
+Here's what can do instead:
+
+.. code-block:: python
+
+   def generator():
+       with start_action(action_type="x"):
+           result = make_result()
+       # This is GOOD, no yield inside the start_action() block:
+       yield result
+
 
 Non-Finishing Contexts
 ----------------------

--- a/eliot/__init__.py
+++ b/eliot/__init__.py
@@ -9,11 +9,6 @@ from ._action import (
     start_action, startTask, Action, preserve_context, current_action,
     log_call
 )
-from ._generators import (
-    GeneratorSupportNotEnabled,
-    use_generator_context,
-    eliot_friendly_generator_function,
-)
 from ._output import (
     ILogger,
     Logger,
@@ -88,10 +83,6 @@ __all__ = [
     "current_action",
     "use_asyncio_context",
     "ValidationError",
-
-    "GeneratorSupportNotEnabled",
-    "use_generator_context",
-    "eliot_friendly_generator_function",
 
     # PEP 8 variants:
     "write_traceback",

--- a/eliot/_action.py
+++ b/eliot/_action.py
@@ -57,7 +57,8 @@ class _ExecutionContext(threading.local):
 
     def _get_stack(self):
         """
-        Get the stack for the current asyncio Task.
+        Get the stack for the current thread, or the sub-stack if sub-stacks
+        are enabled.
         """
         stack = self.get_sub_context()
         if stack is None:

--- a/eliot/tests/test_generators.py
+++ b/eliot/tests/test_generators.py
@@ -20,7 +20,7 @@ from .. import (
     use_generator_context,
     eliot_friendly_generator_function,
 )
-from .._action import _context
+from .._action import _context_owner
 
 
 def assert_expected_action_tree(testcase, logger, expected_action_type, expected_type_tree):
@@ -84,10 +84,7 @@ class EliotFriendlyGeneratorFunctionTests(TestCase):
 
     def setUp(self):
         use_generator_context()
-
-        def cleanup():
-            _context.get_sub_context = lambda: None
-        self.addCleanup(cleanup)
+        self.addCleanup(_context_owner.reset)
 
     @capture_logging(None)
     def test_yield_none(self, logger):
@@ -96,6 +93,7 @@ class EliotFriendlyGeneratorFunctionTests(TestCase):
             Message.log(message_type=u"hello")
             yield
             Message.log(message_type=u"goodbye")
+        g.debug = True  # output yielded messages
 
         with start_action(action_type=u"the-action"):
             list(g())
@@ -116,6 +114,7 @@ class EliotFriendlyGeneratorFunctionTests(TestCase):
             Message.log(message_type=u"hello")
             yield expected
             Message.log(message_type=u"goodbye")
+        g.debug = True  # output yielded messages
 
         with start_action(action_type=u"the-action"):
             self.assertEqual([expected], list(g()))
@@ -137,6 +136,7 @@ class EliotFriendlyGeneratorFunctionTests(TestCase):
                 yield None
                 Message.log(message_type=u"c")
             Message.log(message_type=u"d")
+        g.debug = True  # output yielded messages
 
         with start_action(action_type=u"the-action"):
             list(g())
@@ -164,6 +164,7 @@ class EliotFriendlyGeneratorFunctionTests(TestCase):
                     Message.log(message_type=u"c")
                 Message.log(message_type=u"d")
             Message.log(message_type=u"e")
+        g.debug = True  # output yielded messages
 
         with start_action(action_type=u"the-action"):
             list(g())
@@ -199,6 +200,7 @@ class EliotFriendlyGeneratorFunctionTests(TestCase):
 
             Message.log(message_type=u"d")
             yield
+        g.debug = True  # output yielded messages
 
         with start_action(action_type=u"the-action"):
             generator = g()
@@ -241,6 +243,7 @@ class EliotFriendlyGeneratorFunctionTests(TestCase):
                 yield
                 Message.log(message_type=u"{}-c".format(which))
             Message.log(message_type=u"{}-d".format(which))
+        g.debug = True  # output yielded messages
 
         gens = [g(u"1"), g(u"2")]
         with start_action(action_type=u"the-action"):
@@ -282,7 +285,7 @@ class EliotFriendlyGeneratorFunctionTests(TestCase):
                 Message.log(message_type=u"b")
             finally:
                 Message.log(message_type=u"c")
-
+        g.debug = True  # output yielded messages
 
         with start_action(action_type=u"the-action"):
             gen = g()
@@ -309,6 +312,8 @@ class EliotFriendlyGeneratorFunctionTests(TestCase):
                     set(g(False))
                 else:
                     yield
+
+        g.debug = True  # output yielded messages
 
         with start_action(action_type=u"the-action"):
             set(g(True))

--- a/eliot/tests/test_generators.py
+++ b/eliot/tests/test_generators.py
@@ -16,7 +16,7 @@ from ..testing import (
     assertHasAction,
 )
 
-from .. import (
+from .._generators import (
     use_generator_context,
     eliot_friendly_generator_function,
 )

--- a/eliot/tests/test_twisted.py
+++ b/eliot/tests/test_twisted.py
@@ -35,9 +35,6 @@ from ..testing import assertContainsFields, capture_logging
 from .. import removeDestination, addDestination
 from .._traceback import write_traceback
 from .common import FakeSys
-from .. import (
-    use_generator_context,
-)
 
 
 class PassthroughTests(TestCase):

--- a/eliot/tests/test_twisted.py
+++ b/eliot/tests/test_twisted.py
@@ -690,7 +690,8 @@ class InlineCallbacksTests(TestCase):
     longMessage = True
 
     def setUp(self):
-        use_generator_context()
+        # The generator sub-contxt is enabled automatically, so reset back to
+        # normal:
         self.addCleanup(_context_owner.reset)
 
     def _a_b_test(self, logger, g):

--- a/eliot/twisted.py
+++ b/eliot/twisted.py
@@ -249,13 +249,14 @@ class _RedirectLogsForTrial(object):
 redirectLogsForTrial = _RedirectLogsForTrial(sys)
 
 
-def inline_callbacks(original):
+def inline_callbacks(original, debug=False):
     """
     Decorate a function like ``inlineCallbacks`` would but in a more
     Eliot-friendly way.  Use it just like ``inlineCallbacks`` but where you
     want Eliot action contexts to Do The Right Thing inside the decorated
     function.
     """
-    return inlineCallbacks(
-        eliot_friendly_generator_function(original)
-    )
+    f = eliot_friendly_generator_function(original)
+    if debug:
+        f.debug = True
+    return inlineCallbacks(f)

--- a/eliot/twisted.py
+++ b/eliot/twisted.py
@@ -13,7 +13,7 @@ from twisted.internet.defer import inlineCallbacks
 
 from ._action import current_action
 from . import addDestination
-from ._generators import eliot_friendly_generator_function
+from ._generators import eliot_friendly_generator_function, use_generator_context
 
 __all__ = [
     "AlreadyFinished",
@@ -256,6 +256,7 @@ def inline_callbacks(original, debug=False):
     want Eliot action contexts to Do The Right Thing inside the decorated
     function.
     """
+    use_generator_context()
     f = eliot_friendly_generator_function(original)
     if debug:
         f.debug = True


### PR DESCRIPTION
OK, so I guess for this to be merged I'd like:

* [x] `@eliot_friendly_generator_etc.` should probably be private, and it should automatically set the sub-context-factory, unless that turns out to be too tricky (since typically this is done at import time I'm not too worried about performance... but might need a lock.)
* [x] Documentation for generators that basically says "don't do `yield` inside `with start_action`."

Fixes #259.