### PR TITLE
Remove deprecated np.bool alias

### DIFF
--- a/eliot/json.py
+++ b/eliot/json.py
@@ -19,7 +19,7 @@ class EliotJSONEncoder(json.JSONEncoder):
                 return float(o)
             if isinstance(o, numpy.integer):
                 return int(o)
-            if isinstance(o, (numpy.bool, numpy.bool_)):
+            if isinstance(o, numpy.bool_):
                 return bool(o)
             if isinstance(o, numpy.ndarray):
                 if o.size > 10000:


### PR DESCRIPTION
With `numpy==1.21.4`, I get the following warning when logging an array:
```
/home/kale/.local/share/miniconda/envs/aars/lib/python3.9/site-packages/eliot/json.py:22: DeprecationWarning: `np.bool` is a deprecated alias for the builtin `bool`. To silence this warning, use `bool` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.bool_` here.
  Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
    if isinstance(o, (numpy.bool, numpy.bool_)):
```
It seems that `np.bool` is now just an alias for `bool`, so there's no reason to include it in this `isinstance()` check.