### PR TITLE
add pandas and tests

### DIFF
--- a/eliot/json.py
+++ b/eliot/json.py
@@ -14,7 +14,8 @@ class EliotJSONEncoder(json.JSONEncoder):
 
     def default(self, o):
         numpy = sys.modules.get("numpy", None)
-        if numpy is not None:
+        pandas = sys.modules.get("pandas", None)
+        if numpy is not None or pandas is not None:
             if isinstance(o, numpy.floating):
                 return float(o)
             if isinstance(o, numpy.integer):
@@ -30,6 +31,20 @@ class EliotJSONEncoder(json.JSONEncoder):
                     }
                 else:
                     return o.tolist()
+            if isinstance(obj, pandas.DataFrame):
+                shape = {"rows": obj.shape[0], "columns": obj.shape[1]}
+                dtypesDict = obj.dtypes.to_dict()
+                # Convert dtypes to strings for serialization
+                for key, val in dtypesDict.items():
+                    dtypesDict[key] = str(val)
+                # For large dataframes take a sample
+                if obj.memory_usage(deep=True).sum() / 1e6 > 1:
+                    obj = obj.sample(numpy.min([100, len(obj)]))
+                return {
+                    "shape": shape,
+                    "columns": dtypesDict,
+                    "data": obj.to_json(),
+                }
         return json.JSONEncoder.default(self, o)
 
 

--- a/eliot/tests/test_json.py
+++ b/eliot/tests/test_json.py
@@ -12,6 +12,10 @@ try:
     import numpy as np
 except ImportError:
     np = None
+try:
+    import pandas as pd
+except ImportError:
+    pd = None
 
 from eliot.json import EliotJSONEncoder
 
@@ -60,6 +64,21 @@ class EliotJSONEncoderTests(TestCase):
         l2 = [l, np.array([1, 2, 3])]
         roundtripped = loads(dumps(l2, cls=EliotJSONEncoder))
         self.assertEqual([l, [1, 2, 3]], roundtripped)
+
+    @skipUnless(np, "Pandas not installed.")
+    def test_pandas(self):
+        """Pandas objects get serialized to readable JSON."""
+        df = pd.DataFrame({"col1": [0, 1], "col2": ["a", "b"]})
+        l = [df]
+        targetOutput = [
+            {
+                "columns": {"col1": "int64", "col2": "object"},
+                "data": df.to_json(),
+                "shape": {"rows": 2, "columns": 2},
+            }
+        ]
+        roundtripped = loads(dumps(l, cls=EliotJSONEncoder))
+        self.assertEqual(targetOutput, roundtripped)
 
     @skipIf(np, "NumPy is installed.")
     def test_numpy_not_imported(self):


### PR DESCRIPTION
Hi @itamarst  - I extended the jsonencoder to handle pandas in my own code and it worked well. Wondering if you're interested in developing something like this as part of the main repo?

I've just done a quick pass on the code and tests to give you a sense of it. Basically, for a dataframe I have it output the shape, column names with dtypes and a sample of rows.

Let me know if you think it's worth pursuing. Could also just do an example in the readme of the main repo showing how to do this as a custom extension.
Liam