### PR TITLE
Don't error out when logging non-JSON serialisable values

### DIFF
--- a/eliot/json.py
+++ b/eliot/json.py
@@ -7,6 +7,8 @@ from pathlib import Path
 from datetime import date, time
 import platform
 
+from ._util import saferepr
+
 
 class EliotJSONEncoder(json.JSONEncoder):
     """
@@ -88,7 +90,8 @@ def json_default(o: object) -> object:
         if isinstance(o, polars.Datetime):
             return o.isoformat()
 
-    raise TypeError("Unsupported type")
+    # Fall back to repr() to get _some_ useful value to log
+    return saferepr(o)
 
 
 if platform.python_implementation() == "PyPy":

--- a/eliot/tests/test_json.py
+++ b/eliot/tests/test_json.py
@@ -74,7 +74,9 @@ class EliotJSONEncoderTests(TestCase):
         This ensures NumPy isn't a hard dependency.
         """
         weird_val = object()
-        self.assertEqual(dumps([weird_val], default=json_default), dumps([repr(weird_val)]))
+        self.assertEqual(
+            dumps([weird_val], default=json_default), dumps([repr(weird_val)])
+        )
         self.assertEqual(dumps(12, default=json_default), "12")
 
     @skipUnless(np, "NumPy is not installed.")
@@ -210,7 +212,10 @@ class EliotJSONEncoderTests(TestCase):
     def test_unserializable(self):
         """Test that even values without dedicated JSON serialization
         support dump without errors."""
+
         def unserializable():
             pass
 
-        self.assertEqual(dumps(unserializable, default=json_default), dumps(repr(unserializable)))
+        self.assertEqual(
+            dumps(unserializable, default=json_default), dumps(repr(unserializable))
+        )

--- a/eliot/tests/test_json.py
+++ b/eliot/tests/test_json.py
@@ -73,8 +73,8 @@ class EliotJSONEncoderTests(TestCase):
 
         This ensures NumPy isn't a hard dependency.
         """
-        with self.assertRaises(TypeError):
-            dumps([object()], default=json_default)
+        weird_val = object()
+        self.assertEqual(dumps([weird_val], default=json_default), dumps([repr(weird_val)]))
         self.assertEqual(dumps(12, default=json_default), "12")
 
     @skipUnless(np, "NumPy is not installed.")
@@ -206,3 +206,11 @@ class EliotJSONEncoderTests(TestCase):
         obj = TestDataClass(name="test", value=42)
         serialized = loads(dumps(obj, default=json_default))
         self.assertEqual(serialized, {"name": "test", "value": 42})
+
+    def test_unserializable(self):
+        """Test that even values without dedicated JSON serialization
+        support dump without errors."""
+        def unserializable():
+            pass
+
+        self.assertEqual(dumps(unserializable, default=json_default), dumps(repr(unserializable)))

--- a/eliot/tests/test_output.py
+++ b/eliot/tests/test_output.py
@@ -121,7 +121,9 @@ class MemoryLoggerTests(TestCase):
         logger.write(
             {"message_type": "type", "foo": "will become object()"}, serializer
         )
-        self.assertRaises(TypeError, logger.validate)
+        # No exception should be raised, even on values that are not
+        # normally JSON-serialisable like object()
+        logger.validate()
 
     @skipUnless(np, "NumPy is not installed.")
     def test_EliotJSONEncoder(self):
@@ -143,6 +145,14 @@ class MemoryLoggerTests(TestCase):
             None,
         )
         logger.validate()
+
+        # Unlike EliotJSONEncoder, CustomJSONEncoder doesn't have a
+        # fallback for non-serialisable objects
+        logger.write(
+            {"message_type": "type", "unserialisable": object()},
+            None,
+        )
+        self.assertRaises(TypeError, logger.validate)
 
     def test_serialize(self):
         """

--- a/eliot/tests/test_testing.py
+++ b/eliot/tests/test_testing.py
@@ -1045,6 +1045,10 @@ class LowLevelTestingHooks(TestCase):
         # No errors:
         check_for_errors(logger)
 
+        # Unlike EliotJSONEncoder, CustomJSONEncoder doesn't have a
+        # fallback for non-serialisable objects
+        logger = MemoryLogger(encoder=CustomJSONEncoder)
+
         # Now long something unserializable to JSON:
         logger.write({"message_type": object()})
         with self.assertRaises(TypeError):


### PR DESCRIPTION
The serialiser now falls back on repr() to ensure some usable value can always be logged, even if no other serialiser exists for the value.

Fixes #515