### PR TITLE
Replace deprecated datetime.utcfromtimestamp and utcnow

### DIFF
--- a/commit_msg.txt
+++ b/commit_msg.txt
@@ -1,0 +1,13 @@
+Replace deprecated datetime.utcfromtimestamp and utcnow
+
+datetime.utcfromtimestamp() and datetime.utcnow() are deprecated
+since Python 3.12 and scheduled for removal. This replaces:
+
+- utcfromtimestamp() in prettyprint.py with
+  datetime.fromtimestamp(ts, tz=timezone.utc), stripping the
+  +00:00 offset so the output stays as before (ISO format + Z)
+
+- utcnow() in a test expression with datetime.now(), since the
+  test only checks that the subtraction produces a timedelta
+
+Fixes #517

--- a/eliot/prettyprint.py
+++ b/eliot/prettyprint.py
@@ -4,7 +4,7 @@ API and command-line support for human-readable Eliot messages.
 
 import pprint
 import argparse
-from datetime import datetime
+from datetime import datetime, timezone
 from sys import stdin, stdout
 from collections import OrderedDict
 from json import dumps
@@ -44,16 +44,14 @@ _first_fields = [ACTION_TYPE_FIELD, MESSAGE_TYPE_FIELD, ACTION_STATUS_FIELD]
 
 def _render_timestamp(message: dict, local_timezone: bool) -> str:
     """Convert a message's timestamp to a string."""
-    # If we were returning or storing the datetime we'd want to use an
-    # explicit timezone instead of a naive datetime, but since we're
-    # just using it for formatting we needn't bother.
     if local_timezone:
         dt = datetime.fromtimestamp(message[TIMESTAMP_FIELD])
     else:
-        dt = datetime.utcfromtimestamp(message[TIMESTAMP_FIELD])
+        dt = datetime.fromtimestamp(message[TIMESTAMP_FIELD], tz=timezone.utc)
     result = dt.isoformat(sep="T")
     if not local_timezone:
-        result += "Z"
+        # Strip the +00:00 suffix and use Z instead
+        result = result.replace("+00:00", "") + "Z"
     return result
 
 

--- a/eliot/tests/test_filter.py
+++ b/eliot/tests/test_filter.py
@@ -60,7 +60,7 @@ class EliotFilterTests(TestCase):
         built-ins.
         """
         result = self.evaluateExpression(
-            "isinstance(datetime.utcnow() - datetime.utcnow(), timedelta)", {}
+            "isinstance(datetime.now() - datetime.now(), timedelta)", {}
         )
         self.assertEqual(result, True)
 


### PR DESCRIPTION
Fixes #517.

`datetime.utcfromtimestamp()` and `datetime.utcnow()` have been deprecated since Python 3.12 and are scheduled for removal.

This replaces:
- `datetime.utcfromtimestamp()` in `prettyprint.py` with `datetime.fromtimestamp(ts, tz=timezone.utc)`. The `+00:00` suffix is stripped so the output format stays the same (ISO 8601 with trailing `Z`).
- `datetime.utcnow()` in a test expression with `datetime.now()`, since the test only checks that subtracting two datetimes produces a `timedelta` instance.
