### PR TITLE
Fix typos in comments, docstrings, and docs

### DIFF
--- a/docs/source/generating/asyncio.rst
+++ b/docs/source/generating/asyncio.rst
@@ -3,7 +3,7 @@
 Asyncio/Trio Coroutine Support
 ==============================
 
-As of Eliot 1.8, ``asyncio`` and ``trio`` coroutines have appropriate context propogation for Eliot, automatically.
+As of Eliot 1.8, ``asyncio`` and ``trio`` coroutines have appropriate context propagation for Eliot, automatically.
 
 Asyncio
 --------

--- a/eliot/__init__.py
+++ b/eliot/__init__.py
@@ -40,7 +40,7 @@ def use_asyncio_context():
     )
 
 
-# Backwards compatibilty:
+# Backwards compatibility:
 addDestination = add_destination
 removeDestination = Logger._destinations.remove
 addGlobalFields = Logger._destinations.addGlobalFields

--- a/eliot/_action.py
+++ b/eliot/_action.py
@@ -165,7 +165,7 @@ import time
 
 class Action(object):
     """
-    Part of a nested heirarchy of ongoing actions.
+    Part of a nested hierarchy of ongoing actions.
 
     An action has a start and an end; a message is logged for each.
 

--- a/eliot/_message.py
+++ b/eliot/_message.py
@@ -26,7 +26,7 @@ class Message(object):
     may be auto-populated by logstash).
     """
 
-    # Overrideable for testing purposes:
+    # Overridable for testing purposes:
     _time = time.time
 
     @classmethod

--- a/eliot/_output.py
+++ b/eliot/_output.py
@@ -85,7 +85,7 @@ class Destinations(object):
                 dest(message)
             except Exception as e:
                 # If the destination is broken not because of a specific
-                # message, but rather continously, we will get a
+                # message, but rather continuously, we will get a
                 # "eliot:destination_failure" log message logged, and so we
                 # want to ensure it doesn't do infinite recursion.
                 if message.get("message_type", None) != DESTINATION_FAILURE:

--- a/eliot/_validation.py
+++ b/eliot/_validation.py
@@ -392,7 +392,7 @@ class ActionType(object):
     @type description: C{str}
     """
 
-    # Overrideable hook for testing; need staticmethod() so functions don't
+    # Overridable hook for testing; need staticmethod() so functions don't
     # get turned into methods.
     _start_action = staticmethod(start_action)
     _startTask = staticmethod(startTask)

--- a/eliot/tests/test_action.py
+++ b/eliot/tests/test_action.py
@@ -292,7 +292,7 @@ class ActionTests(TestCase):
 
     def test_withContextUnsetOnRaise(self):
         """
-        L{Action.conext().__exit__} unsets the action if the block raises an
+        L{Action.context().__exit__} unsets the action if the block raises an
         exception.
         """
         action = Action(MemoryLogger(), "", TaskLevel(level=[]), "")

--- a/eliot/tests/test_output.py
+++ b/eliot/tests/test_output.py
@@ -419,7 +419,7 @@ class DestinationsTests(TestCase):
     def test_remove(self):
         """
         A destination removed with L{Destinations.remove} will no longer
-        receive messages from L{Destionations.add} calls.
+        receive messages from L{Destinations.add} calls.
         """
         destinations = Destinations()
         message = {"hello": 123}


### PR DESCRIPTION
Fix several spelling mistakes found by codespell:

- `compatibilty` → `compatibility` in `eliot/__init__.py` (comment)
- `heirarchy` → `hierarchy` in `eliot/_action.py` (class docstring)
- `Overrideable` → `Overridable` in `eliot/_message.py` and `eliot/_validation.py` (comments)
- `continously` → `continuously` in `eliot/_output.py` (inline comment)
- `conext` → `context` in `eliot/tests/test_action.py` (test docstring)
- `Destionations` → `Destinations` in `eliot/tests/test_output.py` (test docstring)
- `propogation` → `propagation` in `docs/source/generating/asyncio.rst` (documentation)

No logic changes, tests, or public API affected.